### PR TITLE
modified _sub-footer-strip so no overflow on smaller devices

### DIFF
--- a/src/scss/components/_sub-footer.scss
+++ b/src/scss/components/_sub-footer.scss
@@ -7,6 +7,8 @@
 .sub-footer {
   display: flex;
   justify-content: space-between;
+  // Added by ali to prevent website overflowing page
+  overflow-x: hidden;
   ul {
     list-style: none;
     margin: 0;


### PR DESCRIPTION
The website URL on the subfooter would overflow on smaller device causing white space on the right side of the device. Adding overflow-x: hidden; would truncate the part that overflows and fixes the issue

![image](https://user-images.githubusercontent.com/33200146/83343639-3b967b80-a2cb-11ea-9db8-4db99a75d62f.png)
